### PR TITLE
fix: deleted tag's frame when the tag don't exist

### DIFF
--- a/templates/html/top.html
+++ b/templates/html/top.html
@@ -71,12 +71,17 @@
           </div>
           <div class="tags-and-form-items">
             <div class="topic-tags">
-              {% comment %}タグの表示数の上限を3つに設定{% endcomment %}
-              {% for tag in topic.tags.names|tag_limit:3 %}
-                <div class="topic-tag">
-                  <small>{{ tag }}</small>
-                </div>
-              {% endfor %}
+              {% if topic.tags.names|length != 1 %}
+              {% comment %} 
+              タグが存在しないときの条件分岐
+              {% endcomment %}
+                {% for tag in topic.tags.names|tag_limit:3 %}
+                  {% comment %}タグの表示数の上限を3つに設定{% endcomment %}
+                  <div class="topic-tag">
+                    <small>{{ tag }}</small>
+                  </div>
+                {% endfor %}
+              {% endif %}
               {% comment %} 
 
               vscodeでフォーマットすると以下のようになるけど、これは正しくないみたいです


### PR DESCRIPTION
## 概要

tagがないときに空のタグが生成されるバグを修正

## 変更の種類

- [x] バグ修正
- [ ] 新しい機能の追加
- [ ] ドキュメンテーションの変更
- [ ] テストの追加/修正
- [ ] パフォーマンスの改善
- [ ] その他（具体的に書いてください）

## 関連するイシュー

https://github.com/Team-west-JAPAN/CivicSeek/issues/29

## テストの概要

[変更に関連するテストの概要を書いてください。]

## スクリーンショット（オプション）

![image](https://github.com/Team-west-JAPAN/CivicSeek/assets/103845269/8494a0ea-6232-4945-b81a-63f1459c0e36)


## 注意事項

[注意事項や特定のレビューを依頼する点があれば書いてください。]

## チェックリスト

- [ ] コードはスタイルガイドに従っている
- [ ] テストが追加/修正されている
- [ ] ドキュメンテーションが更新されている
- [x] 関連するイシューへのリンクが含まれている
- [x] すべてのテストが通過している

## その他の情報

[その他プルリクエストに関連する情報があればここに書いてください。]
